### PR TITLE
Add trash retention option for contacts

### DIFF
--- a/CRM/DataRetentionPolicy/ExtensionUtil.php
+++ b/CRM/DataRetentionPolicy/ExtensionUtil.php
@@ -1,0 +1,21 @@
+<?php
+
+class CRM_DataRetentionPolicy_ExtensionUtil {
+
+  const SHORT_NAME = 'dataretentionpolicy';
+  const LONG_NAME = 'org.example.dataretentionpolicy';
+  const CLASS_PREFIX = 'CRM_DataRetentionPolicy';
+
+  public static function ts($text, $params = []) {
+    return E::ts($text, $params);
+  }
+
+}
+
+class E extends CRM_Extension_System {
+
+  public static function ts($text, $params = []) {
+    return CRM_Extension_System::singleton()->translate(self::LONG_NAME, $text, $params);
+  }
+
+}

--- a/CRM/DataRetentionPolicy/Form/Settings.php
+++ b/CRM/DataRetentionPolicy/Form/Settings.php
@@ -1,0 +1,78 @@
+<?php
+
+use CRM_DataRetentionPolicy_ExtensionUtil as E;
+
+class CRM_DataRetentionPolicy_Form_Settings extends CRM_Core_Form {
+
+  protected $settingKeys = [
+    'data_retention_contact_years' => 'contact',
+    'data_retention_contact_trash_days' => 'contact_trash',
+    'data_retention_participant_years' => 'participant',
+    'data_retention_contribution_years' => 'contribution',
+  ];
+
+  public function buildQuickForm() {
+    $this->setTitle(E::ts('Data Retention Policy Settings'));
+
+    $definitions = $this->getEntityDefinitions();
+    foreach ($definitions as $key => $definition) {
+      $this->add('text', $key, $definition['label'], ['size' => 4, 'maxlength' => 3]);
+      $ruleMessage = !empty($definition['rule_message']) ? $definition['rule_message'] : E::ts('Please enter a whole number or leave blank to disable deletion.');
+      $this->addRule($key, $ruleMessage, 'integer');
+    }
+
+    $this->assign('entityDefinitions', $definitions);
+
+    $this->addButtons([
+      ['type' => 'submit', 'name' => E::ts('Save'), 'isDefault' => TRUE],
+      ['type' => 'cancel', 'name' => E::ts('Cancel')],
+    ]);
+  }
+
+  public function setDefaultValues() {
+    $defaults = [];
+    $settings = Civi::settings();
+    foreach (array_keys($this->settingKeys) as $setting) {
+      $defaults[$setting] = $settings->get($setting);
+    }
+    return $defaults;
+  }
+
+  public function postProcess() {
+    $values = $this->exportValues();
+    $settings = Civi::settings();
+
+    foreach (array_keys($this->settingKeys) as $setting) {
+      $value = CRM_Utils_Array::value($setting, $values);
+      $value = is_numeric($value) ? (int) $value : 0;
+      if ($value < 0) {
+        $value = 0;
+      }
+      $settings->set($setting, $value);
+    }
+
+    CRM_Core_Session::setStatus(E::ts('Data retention policy settings have been saved.'), E::ts('Saved'), 'success');
+  }
+
+  protected function getEntityDefinitions() {
+    return [
+      'data_retention_contact_years' => [
+        'label' => E::ts('Contact records (years)'),
+        'description' => E::ts('Contacts are deleted when their most recent activity, modification or creation is older than the configured number of years.'),
+      ],
+      'data_retention_contact_trash_days' => [
+        'label' => E::ts('Contacts in trash (days)'),
+        'description' => E::ts('Contacts that have already been deleted (moved to the trash) are permanently removed after the configured number of days in the trash.'),
+      ],
+      'data_retention_participant_years' => [
+        'label' => E::ts('Participant records (years)'),
+        'description' => E::ts('Participants are deleted when their most recent modification or registration is older than the configured number of years.'),
+      ],
+      'data_retention_contribution_years' => [
+        'label' => E::ts('Contribution records (years)'),
+        'description' => E::ts('Contributions are deleted when their receive date (or creation date if receive date is empty) is older than the configured number of years.'),
+      ],
+    ];
+  }
+
+}

--- a/CRM/DataRetentionPolicy/Service/RetentionProcessor.php
+++ b/CRM/DataRetentionPolicy/Service/RetentionProcessor.php
@@ -1,0 +1,109 @@
+<?php
+
+class CRM_DataRetentionPolicy_Service_RetentionProcessor {
+
+  public function applyPolicies() {
+    $settings = Civi::settings();
+    $results = [];
+
+    foreach ($this->getEntityConfigurations() as $settingKey => $config) {
+      $amount = (int) $settings->get($settingKey);
+      if ($amount <= 0) {
+        $results[$config['entity']] = 0;
+        continue;
+      }
+      $cutoff = new DateTime('now', new DateTimeZone('UTC'));
+      $modifierPattern = isset($config['modifier']) ? $config['modifier'] : '-%d years';
+      $cutoff->modify(sprintf($modifierPattern, $amount));
+      $count = $this->deleteExpiredRecords($config, $cutoff);
+      $results[$config['entity']] = $count;
+    }
+
+    return $results;
+  }
+
+  protected function deleteExpiredRecords(array $config, DateTime $cutoff) {
+    $ids = $this->getIdsToDelete($config, $cutoff);
+    $count = 0;
+    foreach ($ids as $id) {
+      $params = ['id' => $id];
+      if (!empty($config['api_params'])) {
+        $params = array_merge($params, $config['api_params']);
+      }
+      try {
+        civicrm_api3($config['api_entity'], 'delete', $params);
+        $count++;
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        Civi::log()->error('Data Retention Policy failed to delete record', [
+          'entity' => $config['entity'],
+          'id' => $id,
+          'message' => $e->getMessage(),
+        ]);
+      }
+    }
+    return $count;
+  }
+
+  protected function getIdsToDelete(array $config, DateTime $cutoff) {
+    $params = [1 => [$cutoff->format('Y-m-d H:i:s'), 'String']];
+    $sql = sprintf(
+      'SELECT %s AS record_id FROM %s WHERE %s IS NOT NULL AND %s < %%1 AND %s',
+      $config['id_field'],
+      $config['table'],
+      $config['date_expression'],
+      $config['date_expression'],
+      $config['additional_where']
+    );
+
+    $dao = CRM_Core_DAO::executeQuery($sql, $params);
+    $ids = [];
+    while ($dao->fetch()) {
+      $ids[] = $dao->record_id;
+    }
+    return $ids;
+  }
+
+  protected function getEntityConfigurations() {
+    return [
+      'data_retention_contact_years' => [
+        'entity' => 'Contact',
+        'api_entity' => 'Contact',
+        'table' => 'civicrm_contact',
+        'id_field' => 'id',
+        'date_expression' => 'COALESCE(last_activity_date, modified_date, created_date)',
+        'additional_where' => 'is_deleted = 0',
+        'modifier' => '-%d years',
+      ],
+      'data_retention_contact_trash_days' => [
+        'entity' => 'Contact (trash)',
+        'api_entity' => 'Contact',
+        'table' => 'civicrm_contact',
+        'id_field' => 'id',
+        'date_expression' => 'modified_date',
+        'additional_where' => 'is_deleted = 1',
+        'modifier' => '-%d days',
+        'api_params' => ['skip_undelete' => 1],
+      ],
+      'data_retention_participant_years' => [
+        'entity' => 'Participant',
+        'api_entity' => 'Participant',
+        'table' => 'civicrm_participant',
+        'id_field' => 'id',
+        'date_expression' => 'COALESCE(modified_date, register_date, created_date)',
+        'additional_where' => '1',
+        'modifier' => '-%d years',
+      ],
+      'data_retention_contribution_years' => [
+        'entity' => 'Contribution',
+        'api_entity' => 'Contribution',
+        'table' => 'civicrm_contribution',
+        'id_field' => 'id',
+        'date_expression' => 'COALESCE(receive_date, modified_date, created_date)',
+        'additional_where' => '1',
+        'modifier' => '-%d years',
+      ],
+    ];
+  }
+
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# CiviCRM Data Retention Policy
+
+This extension provides a configurable data retention policy for CiviCRM installations. Administrators can define how long specific record types should be kept, and a scheduled job enforces those rules by deleting records whose activity is older than the configured window.
+
+## Features
+
+* New **Data Retention Policy** settings screen under `Administer » System Settings`.
+* Individual retention periods (in years) for contacts, participants, and contributions.
+* Separate control (in days) for how long deleted contacts remain in the trash before being purged permanently.
+* Scheduled job (`Apply Data Retention Policies`) which deletes records older than the defined retention window using the CiviCRM API.
+* Logging for records which cannot be deleted by the scheduled job.
+
+## Installation
+
+1. Copy the extension directory to your CiviCRM extension directory.
+2. Enable the extension from **Administer » System Settings » Extensions**.
+
+## Configuration
+
+1. Navigate to **Administer » System Settings » Data Retention Policy**.
+2. Enter the retention period in years for each entity you want to purge automatically. Use `0` (or leave blank) to disable deletion for that entity. Configure the number of days that contacts should remain in the trash before they are permanently removed.
+3. Save the settings.
+
+The scheduled job evaluates the following activity dates when determining whether a record should be deleted:
+
+| Entity        | Activity field(s) used |
+| ------------- | ---------------------- |
+| Contacts      | `last_activity_date`, falling back to `modified_date` or `created_date` |
+| Contacts (trash) | `modified_date` |
+| Participants  | `modified_date`, falling back to `register_date` or `create_date` |
+| Contributions | `receive_date`, falling back to `modified_date` or `create_date` |
+
+## Scheduled Job
+
+The extension registers a scheduled job named **Apply Data Retention Policies**. Review the job in **Administer » System Settings » Scheduled Jobs** and adjust the execution schedule to match your compliance needs. When run, the job reports how many records were deleted per entity and logs any failures to the CiviCRM log.
+
+> ⚠️ **Important:** Deletion is permanent. Ensure that the configured retention windows align with your organisation's policies and any legal requirements before enabling the scheduled job.
+
+## Development
+
+The extension key is `org.example.dataretentionpolicy`. Contributions are welcome via pull requests.

--- a/api/v3/DataRetentionPolicyJob/Run.php
+++ b/api/v3/DataRetentionPolicyJob/Run.php
@@ -1,0 +1,21 @@
+<?php
+
+use CRM_DataRetentionPolicy_ExtensionUtil as E;
+
+function civicrm_api3_data_retention_policy_job_run($params) {
+  $processor = new CRM_DataRetentionPolicy_Service_RetentionProcessor();
+  $results = $processor->applyPolicies();
+
+  $messages = [];
+  $total = 0;
+  foreach ($results as $entity => $count) {
+    $messages[] = sprintf('%s: %d', $entity, $count);
+    $total += $count;
+  }
+
+  return civicrm_api3_create_success([
+    'total_deleted' => $total,
+    'details' => $results,
+    'message' => E::ts('Deleted records - %1', [1 => implode(', ', $messages)]),
+  ], $params, 'DataRetentionPolicyJob', 'run');
+}

--- a/dataretentionpolicy.php
+++ b/dataretentionpolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+use CRM_DataRetentionPolicy_ExtensionUtil as E;
+
+function dataretentionpolicy_civicrm_config(&$config) {}
+
+function dataretentionpolicy_civicrm_install() {
+  return TRUE;
+}
+
+function dataretentionpolicy_civicrm_uninstall() {
+  return TRUE;
+}
+
+function dataretentionpolicy_civicrm_enable() {
+  return TRUE;
+}
+
+function dataretentionpolicy_civicrm_disable() {
+  return TRUE;
+}
+
+function dataretentionpolicy_civicrm_navigationMenu(&$menu) {
+  $administerMenuId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Administer', 'id', 'name');
+  if (!$administerMenuId || empty($menu[$administerMenuId]['child'])) {
+    return;
+  }
+  foreach ($menu[$administerMenuId]['child'] as $id => $item) {
+    if ($item['name'] === 'System Settings') {
+      $childMenu =& $menu[$administerMenuId]['child'][$id]['child'];
+      if (!is_array($childMenu)) {
+        $childMenu = [];
+      }
+      $weight = empty($childMenu) ? 0 : (int) CRM_Utils_Array::value('weight', end($childMenu), 0) + 1;
+      $navId = CRM_Core_DAO::singleValueQuery('SELECT COALESCE(MAX(id), 0) + 1 FROM civicrm_navigation');
+      $childMenu[] = [
+        'attributes' => [
+          'label' => E::ts('Data Retention Policy'),
+          'name' => 'Data Retention Policy',
+          'url' => 'civicrm/admin/dataretentionpolicy/settings',
+          'permission' => 'administer CiviCRM',
+          'operator' => NULL,
+          'separator' => 0,
+          'parentID' => $id,
+          'navID' => $navId,
+          'weight' => $weight,
+        ],
+      ];
+      break;
+    }
+  }
+}
+
+function dataretentionpolicy_civicrm_xmlMenu(&$files) {
+  if (!is_array($files)) {
+    $files = [];
+  }
+  $files[] = __DIR__ . DIRECTORY_SEPARATOR . 'xml' . DIRECTORY_SEPARATOR . 'Menu' . DIRECTORY_SEPARATOR . 'dataretentionpolicy.xml';
+}
+
+function dataretentionpolicy_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
+  $metaDataFolders[] = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
+}
+
+function dataretentionpolicy_civicrm_jobTypes(&$jobTypes) {
+  $jobTypes['data_retention_policy_cleanup'] = [
+    'name' => 'data_retention_policy_cleanup',
+    'label' => E::ts('Apply Data Retention Policies'),
+    'description' => E::ts('Delete contacts and related records that exceed configured retention periods.'),
+    'is_active' => 1,
+    'api_entity' => 'DataRetentionPolicyJob',
+    'api_action' => 'run',
+  ];
+}

--- a/info.xml
+++ b/info.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<extension key="org.example.dataretentionpolicy" type="module" name="Data Retention Policy" class="CRM_DataRetentionPolicy_ExtensionUtil" start="auto" version="1.0">
+  <file>dataretentionpolicy.php</file>
+  <requires>
+    <required extension="org.civicrm.core" min="5.0"/>
+  </requires>
+  <license>AGPL-3.0</license>
+  <copyright>Copyright (C) 2024 Example</copyright>
+  <description>Provides configurable data retention policies and a scheduled job to purge expired records.</description>
+</extension>

--- a/settings/data_retention.setting.php
+++ b/settings/data_retention.setting.php
@@ -1,0 +1,34 @@
+<?php
+
+use CRM_DataRetentionPolicy_ExtensionUtil as E;
+
+return [
+  'data_retention_contact_years' => [
+    'name' => 'data_retention_contact_years',
+    'type' => 'Integer',
+    'title' => E::ts('Contact retention period (years)'),
+    'description' => E::ts('Delete contacts when they have no recorded activity newer than the configured number of years.'),
+    'default' => 0,
+  ],
+  'data_retention_contact_trash_days' => [
+    'name' => 'data_retention_contact_trash_days',
+    'type' => 'Integer',
+    'title' => E::ts('Contact trash retention period (days)'),
+    'description' => E::ts('Permanently delete contacts that have remained in the trash for the configured number of days.'),
+    'default' => 0,
+  ],
+  'data_retention_participant_years' => [
+    'name' => 'data_retention_participant_years',
+    'type' => 'Integer',
+    'title' => E::ts('Participant retention period (years)'),
+    'description' => E::ts('Delete participant records when their most recent update is older than the configured number of years.'),
+    'default' => 0,
+  ],
+  'data_retention_contribution_years' => [
+    'name' => 'data_retention_contribution_years',
+    'type' => 'Integer',
+    'title' => E::ts('Contribution retention period (years)'),
+    'description' => E::ts('Delete contribution records when their receive date is older than the configured number of years.'),
+    'default' => 0,
+  ],
+];

--- a/templates/CRM/DataRetentionPolicy/Form/Settings.tpl
+++ b/templates/CRM/DataRetentionPolicy/Form/Settings.tpl
@@ -1,0 +1,14 @@
+{include file="CRM/common/formButtons.tpl" location="top"}
+<div class="crm-block crm-form-block">
+  {foreach from=$entityDefinitions key=key item=definition}
+    <div class="crm-section">
+      <div class="label">{$form.$key.label}</div>
+      <div class="content">
+        {$form.$key.html}
+        <div class="description">{$definition.description}</div>
+      </div>
+      <div class="clear"></div>
+    </div>
+  {/foreach}
+</div>
+{include file="CRM/common/formButtons.tpl" location="bottom"}

--- a/xml/Menu/dataretentionpolicy.xml
+++ b/xml/Menu/dataretentionpolicy.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<menu>
+  <item>
+    <path>civicrm/admin/dataretentionpolicy/settings</path>
+    <page_callback>CRM_DataRetentionPolicy_Form_Settings</page_callback>
+    <title>Data Retention Policy</title>
+    <access_arguments>administer CiviCRM</access_arguments>
+    <page_type>Form</page_type>
+    <is_public>0</is_public>
+    <is_active>1</is_active>
+  </item>
+</menu>


### PR DESCRIPTION
## Summary
- add a configurable trash-retention period for contacts and surface it in the settings UI
- allow the retention processor to purge trashed contacts permanently using the configured number of days
- document the new trash retention behaviour for administrators

## Testing
- for f in $(find . -name '*.php'); do php -l $f; done

------
https://chatgpt.com/codex/tasks/task_b_68db9501da5083259798de58cc3eee64