### PR TITLE
Add extension metadata for backend display

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -1,9 +1,21 @@
 <?xml version="1.0"?>
 <extension key="uk.co.encircle.dataretentionpolicy" type="module" name="Data Retention Policy" class="CRM_DataRetentionPolicy_ExtensionUtil" start="auto" version="1.0">
   <file>dataretentionpolicy.php</file>
+  <version>1.0</version>
+  <releaseDate>2025-09-30</releaseDate>
+  <maintainer>
+    <author>enCircle Solutions Ltd</author>
+  </maintainer>
   <requires>
     <required extension="org.civicrm.core" min="5.0"/>
   </requires>
+  <compatibility>
+    <civicrm>
+      <min>5.0</min>
+    </civicrm>
+    <php>8.1</php>
+    <smarty>5</smarty>
+  </compatibility>
   <license>AGPL-3.0</license>
   <copyright>Copyright (C) 2024 Example</copyright>
   <description>Provides configurable data retention policies and a scheduled job to purge expired records.</description>


### PR DESCRIPTION
## Summary
- add maintainer, version, release date, and compatibility metadata to the extension manifest so CiviCRM backend shows the details

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68dbaeda2fd4832588f696fb1a791102