### PR TITLE
Handle missing translate support in ExtensionUtil ts helper

### DIFF
--- a/CRM/DataRetentionPolicy/ExtensionUtil.php
+++ b/CRM/DataRetentionPolicy/ExtensionUtil.php
@@ -17,7 +17,25 @@ class CRM_DataRetentionPolicy_ExtensionUtil {
 class E extends CRM_Extension_System {
 
   public static function ts($text, $params = []) {
-    return CRM_Extension_System::singleton()->translate(self::LONG_NAME, $text, $params);
+    $extensionSystem = CRM_Extension_System::singleton();
+
+    if (method_exists($extensionSystem, 'translate')) {
+      return $extensionSystem->translate(
+        CRM_DataRetentionPolicy_ExtensionUtil::LONG_NAME,
+        $text,
+        $params
+      );
+    }
+
+    if (!is_array($params)) {
+      $params = (array) $params;
+    }
+
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = CRM_DataRetentionPolicy_ExtensionUtil::LONG_NAME;
+    }
+
+    return ts($text, $params);
   }
 
 }


### PR DESCRIPTION
## Summary
- update the extension translation helper to fall back to the global ts() when CRM_Extension_System::translate() is unavailable

## Testing
- php -l CRM/DataRetentionPolicy/ExtensionUtil.php

------
https://chatgpt.com/codex/tasks/task_b_68dbb8200a9883259f7beef573c2ec58