### PR TITLE
Fix menu parent path for settings screen

### DIFF
--- a/xml/Menu/dataretentionpolicy.xml
+++ b/xml/Menu/dataretentionpolicy.xml
@@ -2,7 +2,7 @@
 <menu>
   <item>
     <path>civicrm/admin/dataretentionpolicy/settings</path>
-    <parent>civicrm/admin/systemSettings</parent>
+    <parent>civicrm/admin/system</parent>
     <page_callback>CRM_DataRetentionPolicy_Form_Settings</page_callback>
     <title>Data Retention Policy</title>
     <access_arguments>administer CiviCRM</access_arguments>


### PR DESCRIPTION
## Summary
- update the navigation menu parent to use the correct Administer » System Settings path so the configuration link appears

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dbbc9e88c0832593d20cc9960660d1