### PR TITLE
Ensure Data Retention Policy menu item appears in navigation

### DIFF
--- a/dataretentionpolicy.php
+++ b/dataretentionpolicy.php
@@ -31,6 +31,24 @@ function dataretentionpolicy_civicrm_alterSettingsFolders(&$metaDataFolders = NU
   $metaDataFolders[] = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
 }
 
+function dataretentionpolicy_civicrm_navigationMenu(&$menu) {
+  $path = ['Administer', 'System Settings'];
+
+  $item = [
+    'attributes' => [
+      'label' => E::ts('Data Retention Policy'),
+      'name' => 'data_retention_policy_settings',
+      'url' => 'civicrm/admin/dataretentionpolicy/settings?reset=1',
+      'permission' => 'administer CiviCRM',
+      'operator' => NULL,
+      'separator' => 0,
+      'active' => 1,
+    ],
+  ];
+
+  _dataretentionpolicy_insert_navigation_menu($menu, $path, $item);
+}
+
 function dataretentionpolicy_civicrm_jobTypes(&$jobTypes) {
   $jobTypes['data_retention_policy_cleanup'] = [
     'name' => 'data_retention_policy_cleanup',
@@ -59,4 +77,41 @@ function dataretentionpolicy_civicrm_managed(&$entities) {
       'job_type' => 'data_retention_policy_cleanup',
     ],
   ];
+}
+
+function _dataretentionpolicy_insert_navigation_menu(&$menu, $path, $item) {
+  if (is_string($path)) {
+    $path = explode('/', $path);
+  }
+
+  if (empty($path)) {
+    foreach ($menu as $existing) {
+      if (!empty($existing['attributes']['url']) && $existing['attributes']['url'] === $item['attributes']['url']) {
+        return FALSE;
+      }
+    }
+
+    $menu[] = $item;
+    return TRUE;
+  }
+
+  $part = array_shift($path);
+  foreach ($menu as &$entry) {
+    if (empty($entry['attributes']['name']) && empty($entry['attributes']['label'])) {
+      continue;
+    }
+
+    $name = CRM_Utils_Array::value('name', $entry['attributes']);
+    $label = CRM_Utils_Array::value('label', $entry['attributes']);
+
+    if ($name === $part || $label === $part) {
+      if (!isset($entry['child'])) {
+        $entry['child'] = [];
+      }
+
+      return _dataretentionpolicy_insert_navigation_menu($entry['child'], $path, $item);
+    }
+  }
+
+  return FALSE;
 }


### PR DESCRIPTION
## Summary
- add a navigationMenu hook to always register the Data Retention Policy settings page under Administer » System Settings
- guard against duplicate menu entries when injecting the menu item

## Testing
- php -l dataretentionpolicy.php

------
https://chatgpt.com/codex/tasks/task_b_68dbc2b611208325be5a95480ee683ea