### PR TITLE
Register extension resources during config bootstrap

### DIFF
--- a/dataretentionpolicy.php
+++ b/dataretentionpolicy.php
@@ -2,7 +2,11 @@
 
 use CRM_DataRetentionPolicy_ExtensionUtil as E;
 
-function dataretentionpolicy_civicrm_config(&$config) {}
+function dataretentionpolicy_civicrm_config(&$config) {
+  set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__);
+  CRM_Core_ClassLoader::singleton()->register();
+  CRM_Core_Smarty::singleton()->addTemplateDir(__DIR__ . DIRECTORY_SEPARATOR . 'templates');
+}
 
 function dataretentionpolicy_civicrm_install() {
   return TRUE;


### PR DESCRIPTION
## Summary
- append the extension directory to the PHP include path during config bootstrap
- register the CiviCRM class loader and expose the extension template directory

## Testing
- not run (environment only includes extension source)

------
https://chatgpt.com/codex/tasks/task_b_68dbc67f965c83259bb5c4ebbd94d1cf